### PR TITLE
Improve CI test logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           ctest --test-dir build --output-on-failure --verbose | tee build/ctest.log
       - name: Upload test logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-logs
           path: build/ctest.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,10 @@ jobs:
       - name: Build
         run: cmake --build build -j $(nproc)
       - name: Test
-        run: ctest --test-dir build --output-on-failure
+        run: |
+          ctest --test-dir build --output-on-failure --verbose | tee build/ctest.log
+      - name: Upload test logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-logs
+          path: build/ctest.log


### PR DESCRIPTION
## Summary
- ensure test output is written to a log file
- upload ctest log as a CI artifact
- enable verbose mode so printf output appears in logs

## Testing
- `cmake ..`
- `cmake --build . -j $(nproc)`
- `ctest --output-on-failure --verbose | tee ctest.log >/tmp/ctest_console.log && tail -n 20 ctest.log`


------
https://chatgpt.com/codex/tasks/task_e_684edd8253e483248600553072c4e8ad