### PR TITLE
Store BUP chunks on disk

### DIFF
--- a/include/bup_odb.h
+++ b/include/bup_odb.h
@@ -16,7 +16,7 @@ int bup_backend_free_calls(void);
 int bup_backend_chunk_count(void);
 size_t bup_backend_total_size(void);
 size_t bup_backend_object_chunks(git_odb_backend *backend, const git_oid *oid,
-                                 const void ***chunks, size_t **lengths);
+                                 git_oid **chunk_oids, size_t **lengths);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- store deduplicated chunks as git objects using libgit2
- open repository ODB in backend
- return chunk `git_oid`s in helper API
- update tests for on‑disk chunk storage

## Testing
- `cmake ..`
- `make`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_684ef6b94fb88324b305a7b7ddb22074