### PR TITLE
Refactor chunk objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ pkg_check_modules(LIBGIT2 REQUIRED libgit2)
 include_directories(${LIBGIT2_INCLUDE_DIRS} include)
 link_directories(${LIBGIT2_LIBRARY_DIRS})
 
-add_library(bup_odb STATIC src/bup_odb.c)
+add_library(bup_odb STATIC src/bup_odb.c src/chunk_utils.c)
 target_link_libraries(bup_odb ${LIBGIT2_LIBRARIES})
 
 add_executable(git2_bin src/git2.c)

--- a/include/chunk_utils.h
+++ b/include/chunk_utils.h
@@ -1,0 +1,41 @@
+#ifndef CHUNK_UTILS_H
+#define CHUNK_UTILS_H
+
+#include <git2.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define BUP_WINDOWBITS 6
+#define BUP_WINDOWSIZE (1 << BUP_WINDOWBITS)
+#define BUP_BLOBBITS 12
+#define BUP_MAX_EXTRA_BITS 0
+#define BUP_CHUNK_MASK ((1 << BUP_BLOBBITS) - 1)
+#define BUP_MIN_CHUNK (1 << (BUP_BLOBBITS - BUP_MAX_EXTRA_BITS))
+#define BUP_MAX_CHUNK (1 << (BUP_BLOBBITS + BUP_MAX_EXTRA_BITS))
+#define BUP_ROLL_BASE 31
+#define BUP_ROLL_SHIFT 16
+#define BUP_ROLL_MASK 0xffff
+
+typedef struct {
+    unsigned s1, s2;
+    uint8_t window[BUP_WINDOWSIZE];
+    int wofs;
+} Rollsum;
+
+typedef struct bup_chunk {
+    git_oid oid;
+    size_t len;
+    struct bup_chunk *next;
+} bup_chunk;
+
+void rollsum_init(Rollsum *r);
+void rollsum_roll(Rollsum *r, uint8_t c);
+uint32_t rollsum_digest(const Rollsum *r);
+
+bup_chunk *chunk_get_or_create(git_odb *odb, bup_chunk **pool,
+                               const void *data, size_t len);
+void chunk_pool_free(bup_chunk **pool);
+int chunk_pool_count(void);
+size_t chunk_pool_total_size(void);
+
+#endif /* CHUNK_UTILS_H */

--- a/src/bup_odb.c
+++ b/src/bup_odb.c
@@ -1,4 +1,5 @@
 #include "bup_odb.h"
+#include "chunk_utils.h"
 #include <git2/sys/odb_backend.h>
 #include <git2/odb.h>
 #include <git2.h>
@@ -10,315 +11,67 @@ struct bup_odb_backend {
     git_odb_backend parent;
     char *path;
     git_odb *odb;
-    struct bup_object *objects;
     struct bup_chunk *chunk_pool;
 };
 
 typedef struct bup_odb_backend bup_odb_backend;
 
-typedef struct bup_chunk {
-    git_oid oid;
-    size_t len;
-    int refcount;
-    struct bup_chunk *next_global;
-} bup_chunk;
-
-typedef struct bup_obj_chunk {
-    bup_chunk *chunk;
-    struct bup_obj_chunk *next;
-} bup_obj_chunk;
-
-typedef struct bup_object {
-    git_oid oid;
-    git_object_t type;
-    size_t size;
-    struct bup_obj_chunk *chunks;
-    struct bup_object *next;
-} bup_object;
-
-static struct bup_object *object_create(git_object_t type);
-static int object_add_chunk_oid(bup_odb_backend *b, struct bup_object *obj,
-                                const git_oid *oid, size_t len);
-
 static int read_calls = 0;
 static int write_calls = 0;
 static int free_calls = 0;
-static int chunk_count = 0;
-static size_t chunk_total_size = 0;
 
-
-/*
- * Chunks are stored as regular git blobs.  The parent blob stores a text list
- * of chunk object IDs and lengths.  These helpers serialise and parse that
- * format.
- */
-
-static int write_chunk_list(bup_odb_backend *b, struct bup_object *obj)
+static int parse_chunk_list(const char *data, size_t size,
+                            git_oid **oids, size_t **lengths, size_t *count)
 {
-    size_t count = 0;
-    for (bup_obj_chunk *oc = obj->chunks; oc; oc = oc->next)
-        count++;
-
-    size_t est = count * (GIT_OID_HEXSZ + 1 + 20 + 1);
-    char *buf = malloc(est);
-    if (!buf)
-        return -1;
-
-    char *p = buf;
-    for (bup_obj_chunk *oc = obj->chunks; oc; oc = oc->next) {
-        char hex[GIT_OID_HEXSZ + 1];
-        git_oid_tostr(hex, sizeof(hex), &oc->chunk->oid);
-        int n = sprintf(p, "%s %zu\n", hex, oc->chunk->len);
-        p += n;
-    }
-
-    git_oid oid;
-    int ret = git_odb_write(&oid, b->odb, buf, (size_t)(p - buf), GIT_OBJECT_BLOB);
-    free(buf);
-    if (ret < 0)
-        return -1;
-
-    git_oid_cpy(&obj->oid, &oid);
-    return 0;
-}
-
-static struct bup_object *read_chunk_blob(bup_odb_backend *b, const git_oid *oid)
-{
-    git_odb_object *blob = NULL;
-    if (git_odb_read(&blob, b->odb, oid) < 0)
-        return NULL;
-
-    const char *data = git_odb_object_data(blob);
-    size_t size = git_odb_object_size(blob);
-
-    struct bup_object *obj = object_create(GIT_OBJECT_BLOB);
-    if (!obj) {
-        git_odb_object_free(blob);
-        return NULL;
-    }
-
-    git_oid_cpy(&obj->oid, oid);
     const char *ptr = data;
     const char *end = data + size;
-    char hex[GIT_OID_HEXSZ + 1];
-
+    size_t n = 0;
     while (ptr < end) {
-        if (ptr + GIT_OID_HEXSZ + 1 >= end) {
-            git_odb_object_free(blob);
+        const char *nl = memchr(ptr, '\n', (size_t)(end - ptr));
+        if (!nl)
+            return -1;
+        n++;
+        ptr = nl + 1;
+    }
+
+    git_oid *tmp_oids = malloc(sizeof(git_oid) * n);
+    size_t *tmp_len = malloc(sizeof(size_t) * n);
+    if (!tmp_oids || !tmp_len) {
+        free(tmp_oids);
+        free(tmp_len);
+        return -1;
+    }
+
+    ptr = data;
+    for (size_t i = 0; i < n; i++) {
+        const char *nl = memchr(ptr, '\n', (size_t)(end - ptr));
+        const char *sp = memchr(ptr, ' ', (size_t)(nl - ptr));
+        if (!nl || !sp || (size_t)(sp - ptr) != GIT_OID_HEXSZ)
             goto fail;
-        }
+
+        char hex[GIT_OID_HEXSZ + 1];
         memcpy(hex, ptr, GIT_OID_HEXSZ);
         hex[GIT_OID_HEXSZ] = '\0';
-        ptr += GIT_OID_HEXSZ;
-        if (*ptr != ' ') {
-            git_odb_object_free(blob);
+        if (git_oid_fromstr(&tmp_oids[i], hex) < 0)
             goto fail;
-        }
-        ptr++;
-        char *next = NULL;
-        size_t len = strtoull(ptr, &next, 10);
-        if (!next || next >= end || (*next != '\n' && *next != '\r')) {
-            git_odb_object_free(blob);
-            goto fail;
-        }
-        ptr = next + 1;
 
-        git_oid c_oid;
-        if (git_oid_fromstr(&c_oid, hex) < 0 ||
-            object_add_chunk_oid(b, obj, &c_oid, len) < 0) {
-            git_odb_object_free(blob);
-            goto fail;
-        }
+        tmp_len[i] = (size_t)strtoull(sp + 1, NULL, 10);
+
+        ptr = nl + 1;
     }
 
-    git_odb_object_free(blob);
-    obj->next = b->objects;
-    b->objects = obj;
-    return obj;
+    *oids = tmp_oids;
+    *lengths = tmp_len;
+    *count = n;
+    return 0;
 
 fail:
-    {
-        bup_obj_chunk *oc = obj->chunks;
-        while (oc) {
-            bup_obj_chunk *n = oc->next;
-            if (--oc->chunk->refcount == 0) {
-                bup_chunk **pc = &b->chunk_pool;
-                while (*pc && *pc != oc->chunk)
-                    pc = &(*pc)->next_global;
-                if (*pc)
-                    *pc = oc->chunk->next_global;
-                chunk_total_size -= oc->chunk->len;
-                chunk_count--;
-                free(oc->chunk);
-            }
-            free(oc);
-            oc = n;
-        }
-    }
-    free(obj);
-    return NULL;
+    free(tmp_oids);
+    free(tmp_len);
+    return -1;
 }
 
 
-#define BUP_WINDOWBITS 6
-#define BUP_WINDOWSIZE (1 << BUP_WINDOWBITS)
-#define BUP_BLOBBITS 12
-#define BUP_MAX_EXTRA_BITS 0
-#define BUP_CHUNK_MASK ((1 << BUP_BLOBBITS) - 1)
-#define BUP_MIN_CHUNK (1 << (BUP_BLOBBITS - BUP_MAX_EXTRA_BITS))
-#define BUP_MAX_CHUNK (1 << (BUP_BLOBBITS + BUP_MAX_EXTRA_BITS))
-#define BUP_ROLL_BASE 31
-#define BUP_ROLL_SHIFT 16
-#define BUP_ROLL_MASK 0xffff
-
-typedef struct {
-    unsigned s1, s2;
-    uint8_t window[BUP_WINDOWSIZE];
-    int wofs;
-} Rollsum;
-
-static inline void rollsum_init(Rollsum *r)
-{
-    r->s1 = BUP_WINDOWSIZE * BUP_ROLL_BASE;
-    r->s2 = BUP_WINDOWSIZE * (BUP_WINDOWSIZE - 1) * BUP_ROLL_BASE;
-    r->wofs = 0;
-    memset(r->window, 0, BUP_WINDOWSIZE);
-}
-
-static inline void rollsum_roll(Rollsum *r, uint8_t c)
-{
-    uint8_t drop = r->window[r->wofs];
-    r->s1 += c - drop;
-    r->s2 += r->s1 - (BUP_WINDOWSIZE * (drop + BUP_ROLL_BASE));
-    r->window[r->wofs] = c;
-    r->wofs = (r->wofs + 1) % BUP_WINDOWSIZE;
-}
-
-static inline uint32_t rollsum_digest(Rollsum *r)
-{
-    return (r->s1 << BUP_ROLL_SHIFT) | (r->s2 & BUP_ROLL_MASK);
-}
-
-static bup_chunk *chunk_create(bup_odb_backend *b, const void *data, size_t len)
-{
-    git_oid oid;
-    if (git_odb_write(&oid, b->odb, data, len, GIT_OBJECT_BLOB) < 0)
-        return NULL;
-
-    bup_chunk *c = malloc(sizeof(*c));
-    if (!c)
-        return NULL;
-
-    git_oid_cpy(&c->oid, &oid);
-    c->len = len;
-    c->refcount = 0;
-    c->next_global = NULL;
-    chunk_total_size += len;
-    return c;
-}
-
-static bup_chunk *chunk_get_or_create(bup_odb_backend *b, const void *data, size_t len)
-{
-    git_oid oid;
-    if (git_odb_hash(&oid, data, len, GIT_OBJECT_BLOB) < 0)
-        return NULL;
-
-    for (bup_chunk *c = b->chunk_pool; c; c = c->next_global) {
-        if (git_oid_cmp(&c->oid, &oid) == 0) {
-            c->refcount++;
-            return c;
-        }
-    }
-
-    bup_chunk *c = chunk_create(b, data, len);
-    if (!c)
-        return NULL;
-    c->refcount = 1;
-    c->next_global = b->chunk_pool;
-    b->chunk_pool = c;
-    chunk_count++;
-    return c;
-}
-
-static bup_chunk *chunk_get_or_load(bup_odb_backend *b, const git_oid *oid, size_t len)
-{
-    for (bup_chunk *c = b->chunk_pool; c; c = c->next_global) {
-        if (git_oid_cmp(&c->oid, oid) == 0) {
-            c->refcount++;
-            return c;
-        }
-    }
-
-    bup_chunk *c = malloc(sizeof(*c));
-    if (!c)
-        return NULL;
-    git_oid_cpy(&c->oid, oid);
-    c->len = len;
-    c->refcount = 1;
-    c->next_global = b->chunk_pool;
-    b->chunk_pool = c;
-    chunk_total_size += len;
-    chunk_count++;
-    return c;
-}
-
-static int object_add_chunk_oid(bup_odb_backend *backend, struct bup_object *obj,
-                                const git_oid *oid, size_t len)
-{
-    bup_chunk *c = chunk_get_or_load(backend, oid, len);
-    if (!c)
-        return -1;
-    bup_obj_chunk *oc = malloc(sizeof(*oc));
-    if (!oc)
-        return -1;
-    oc->chunk = c;
-    oc->next = NULL;
-    if (!obj->chunks) {
-        obj->chunks = oc;
-    } else {
-        bup_obj_chunk *tail = obj->chunks;
-        while (tail->next)
-            tail = tail->next;
-        tail->next = oc;
-    }
-    obj->size += len;
-    return 0;
-}
-
-static int object_add_chunk(bup_odb_backend *backend, struct bup_object *obj,
-                            const void *data, size_t len)
-{
-    bup_chunk *c = chunk_get_or_create(backend, data, len);
-    if (!c)
-        return -1;
-    bup_obj_chunk *oc = malloc(sizeof(*oc));
-    if (!oc)
-        return -1;
-    oc->chunk = c;
-    oc->next = NULL;
-    if (!obj->chunks) {
-        obj->chunks = oc;
-    } else {
-        bup_obj_chunk *tail = obj->chunks;
-        while (tail->next)
-            tail = tail->next;
-        tail->next = oc;
-    }
-    obj->size += len;
-    return 0;
-}
-
-static struct bup_object *object_create(git_object_t type)
-{
-    struct bup_object *obj = calloc(1, sizeof(*obj));
-    if (!obj)
-        return NULL;
-    obj->type = type;
-    obj->size = 0;
-    obj->chunks = NULL;
-    obj->next = NULL;
-    return obj;
-}
 
 static int bup_backend_read(void **buffer, size_t *len, git_object_t *type,
                            git_odb_backend *backend, const git_oid *oid)
@@ -326,54 +79,64 @@ static int bup_backend_read(void **buffer, size_t *len, git_object_t *type,
     bup_odb_backend *b = (bup_odb_backend *)backend;
     read_calls++;
 
-    struct bup_object *obj = b->objects;
-    while (obj) {
-        if (git_oid_cmp(&obj->oid, oid) == 0)
-            break;
-        obj = obj->next;
-    }
+    git_odb_object *obj = NULL;
+    if (git_odb_read(&obj, b->odb, oid) < 0)
+        return GIT_ENOTFOUND;
 
-    if (!obj)
-        obj = read_chunk_blob(b, oid);
+    const char *data = git_odb_object_data(obj);
+    size_t size = git_odb_object_size(obj);
 
-    if (!obj) {
-        git_odb_object *base_obj = NULL;
-        if (git_odb_read(&base_obj, b->odb, oid) < 0)
-            return GIT_ENOTFOUND;
-
-        *type = git_odb_object_type(base_obj);
-        *len = git_odb_object_size(base_obj);
-        *buffer = malloc(*len);
+    git_oid *oids = NULL;
+    size_t *lens = NULL;
+    size_t count = 0;
+    if (git_odb_object_type(obj) != GIT_OBJECT_BLOB ||
+        parse_chunk_list(data, size, &oids, &lens, &count) < 0 || count == 0) {
+        *type = git_odb_object_type(obj);
+        *len = size;
+        *buffer = malloc(size);
         if (!*buffer) {
-            git_odb_object_free(base_obj);
+            git_odb_object_free(obj);
             return -1;
         }
-        memcpy(*buffer, git_odb_object_data(base_obj), *len);
-        git_odb_object_free(base_obj);
+        memcpy(*buffer, data, size);
+        git_odb_object_free(obj);
         return 0;
     }
 
-    *type = obj->type;
-    *len = obj->size;
-    *buffer = malloc(obj->size);
-    if (!*buffer)
+    git_odb_object_free(obj);
+
+    size_t total = 0;
+    for (size_t i = 0; i < count; i++)
+        total += lens[i];
+
+    char *buf = malloc(total);
+    if (!buf) {
+        free(oids);
+        free(lens);
         return -1;
+    }
 
     size_t ofs = 0;
-    bup_obj_chunk *oc = obj->chunks;
-    while (oc) {
-        bup_chunk *c = oc->chunk;
+    for (size_t i = 0; i < count; i++) {
         git_odb_object *chunk_obj = NULL;
-        if (git_odb_read(&chunk_obj, b->odb, &c->oid) < 0) {
-            free(*buffer);
+        if (git_odb_read(&chunk_obj, b->odb, &oids[i]) < 0) {
+            free(buf);
+            free(oids);
+            free(lens);
             return -1;
         }
-        memcpy((char *)(*buffer) + ofs, git_odb_object_data(chunk_obj),
+        memcpy(buf + ofs, git_odb_object_data(chunk_obj),
                git_odb_object_size(chunk_obj));
         ofs += git_odb_object_size(chunk_obj);
         git_odb_object_free(chunk_obj);
-        oc = oc->next;
     }
+
+    free(oids);
+    free(lens);
+
+    *type = GIT_OBJECT_BLOB;
+    *len = total;
+    *buffer = buf;
     return 0;
 }
 
@@ -386,10 +149,12 @@ static int bup_backend_write(git_odb_backend *backend, const git_oid *oid,
     if (type != GIT_OBJECT_BLOB)
         return git_odb_write((git_oid *)oid, b->odb, data, len, type);
 
-    struct bup_object *obj = object_create(type);
-    if (!obj)
+    size_t est_count = len / BUP_MIN_CHUNK + 1;
+    size_t est_size = est_count * (GIT_OID_HEXSZ + 1 + 20 + 1);
+    char *list = malloc(est_size);
+    if (!list)
         return -1;
-
+    size_t pos = 0;
     const unsigned char *buf = data;
     Rollsum r;
     rollsum_init(&r);
@@ -404,81 +169,45 @@ static int bup_backend_write(git_odb_backend *backend, const git_oid *oid,
         if (chunk_len >= BUP_MIN_CHUNK &&
             ((rollsum_digest(&r) & BUP_CHUNK_MASK) == 0 ||
              chunk_len >= BUP_MAX_CHUNK)) {
-            if (object_add_chunk(b, obj, buf + chunk_start, chunk_len) < 0)
-                goto error;
+            bup_chunk *c = chunk_get_or_create(b->odb, &b->chunk_pool,
+                                               buf + chunk_start, chunk_len);
+            if (!c) {
+                free(list);
+                return -1;
+            }
+            char hex[GIT_OID_HEXSZ + 1];
+            git_oid_tostr(hex, sizeof(hex), &c->oid);
+            int n = snprintf(list + pos, est_size - pos, "%s %zu\n", hex, c->len);
+            pos += (size_t)n;
             chunk_start = i + 1;
             chunk_len = 0;
         }
     }
 
     if (chunk_len > 0) {
-        if (object_add_chunk(b, obj, buf + chunk_start, chunk_len) < 0)
-            goto error;
-    }
-
-    if (write_chunk_list(b, obj) < 0)
-        goto error;
-
-    obj->next = b->objects;
-    b->objects = obj;
-
-    if (oid)
-        git_oid_cpy((git_oid *)oid, &obj->oid);
-
-    return 0;
-
-error:
-    if (obj) {
-        bup_obj_chunk *oc = obj->chunks;
-        while (oc) {
-            bup_obj_chunk *n = oc->next;
-            bup_chunk *c = oc->chunk;
-            if (--c->refcount == 0) {
-                /* remove from pool */
-                bup_chunk **pc = &b->chunk_pool;
-                while (*pc && *pc != c)
-                    pc = &(*pc)->next_global;
-                if (*pc == c)
-                    *pc = c->next_global;
-                chunk_total_size -= c->len;
-                free(c);
-                chunk_count--;
-            }
-            free(oc);
-            oc = n;
+        bup_chunk *c = chunk_get_or_create(b->odb, &b->chunk_pool,
+                                           buf + chunk_start, chunk_len);
+        if (!c) {
+            free(list);
+            return -1;
         }
-        free(obj);
+        char hex[GIT_OID_HEXSZ + 1];
+        git_oid_tostr(hex, sizeof(hex), &c->oid);
+        int n = snprintf(list + pos, est_size - pos, "%s %zu\n", hex, c->len);
+        pos += (size_t)n;
     }
-    return -1;
+
+    int ret = git_odb_write((git_oid *)oid, b->odb, list, pos,
+                            GIT_OBJECT_BLOB);
+    free(list);
+    return ret;
 }
 
 static void bup_backend_free(git_odb_backend *backend)
 {
     bup_odb_backend *b = (bup_odb_backend *)backend;
     free_calls++;
-    struct bup_object *obj = b->objects;
-    while (obj) {
-        struct bup_object *nobj = obj->next;
-        bup_obj_chunk *oc = obj->chunks;
-        while (oc) {
-            bup_obj_chunk *noc = oc->next;
-            bup_chunk *c = oc->chunk;
-            if (--c->refcount == 0) {
-                bup_chunk **pc = &b->chunk_pool;
-                while (*pc && *pc != c)
-                    pc = &(*pc)->next_global;
-                if (*pc == c)
-                    *pc = c->next_global;
-                chunk_total_size -= c->len;
-                free(c);
-                chunk_count--;
-            }
-            free(oc);
-            oc = noc;
-        }
-        free(obj);
-        obj = nobj;
-    }
+    chunk_pool_free(&b->chunk_pool);
     git_odb_free(b->odb);
     free(b->path);
     free(b);
@@ -506,7 +235,6 @@ int bup_odb_backend_new(git_odb_backend **out, const char *path)
     backend->parent.read = bup_backend_read;
     backend->parent.write = bup_backend_write;
     backend->parent.free = bup_backend_free;
-    backend->objects = NULL;
     backend->chunk_pool = NULL;
 
     *out = (git_odb_backend *)backend;
@@ -535,51 +263,39 @@ int bup_backend_free_calls(void)
 
 int bup_backend_chunk_count(void)
 {
-    return chunk_count;
+    return chunk_pool_count();
 }
 
 size_t bup_backend_total_size(void)
 {
-    return chunk_total_size;
+    return chunk_pool_total_size();
 }
 
 size_t bup_backend_object_chunks(git_odb_backend *backend, const git_oid *oid,
                                  git_oid **chunk_oids, size_t **lengths)
 {
     bup_odb_backend *b = (bup_odb_backend *)backend;
-    struct bup_object *obj = b->objects;
-    while (obj) {
-        if (git_oid_cmp(&obj->oid, oid) == 0)
-            break;
-        obj = obj->next;
-    }
-    if (!obj)
-        obj = read_chunk_blob(b, oid);
-    if (!obj)
+    git_odb_object *obj = NULL;
+    if (git_odb_read(&obj, b->odb, oid) < 0)
         return 0;
 
+    git_oid *oids = NULL;
+    size_t *lens = NULL;
     size_t count = 0;
-    bup_obj_chunk *oc = obj->chunks;
-    while (oc) {
-        count++;
-        oc = oc->next;
+    if (parse_chunk_list(git_odb_object_data(obj), git_odb_object_size(obj),
+                         &oids, &lens, &count) < 0) {
+        git_odb_object_free(obj);
+        return 0;
     }
+    git_odb_object_free(obj);
 
     if (chunk_oids)
-        *chunk_oids = malloc(sizeof(git_oid) * count);
+        *chunk_oids = oids;
+    else
+        free(oids);
     if (lengths)
-        *lengths = malloc(sizeof(size_t) * count);
-
-    oc = obj->chunks;
-    size_t i = 0;
-    while (oc) {
-        if (chunk_oids)
-            git_oid_cpy(&(*chunk_oids)[i], &oc->chunk->oid);
-        if (lengths)
-            (*lengths)[i] = oc->chunk->len;
-        oc = oc->next;
-        i++;
-    }
-
+        *lengths = lens;
+    else
+        free(lens);
     return count;
 }

--- a/src/chunk_utils.c
+++ b/src/chunk_utils.c
@@ -1,0 +1,87 @@
+#include "chunk_utils.h"
+#include <string.h>
+#include <stdlib.h>
+
+static int chunk_count = 0;
+static size_t chunk_total_size = 0;
+
+int chunk_pool_count(void) {
+    return chunk_count;
+}
+
+size_t chunk_pool_total_size(void) {
+    return chunk_total_size;
+}
+
+static bup_chunk *find_chunk(bup_chunk *pool, const git_oid *oid) {
+    for (bup_chunk *c = pool; c; c = c->next)
+        if (git_oid_cmp(&c->oid, oid) == 0)
+            return c;
+    return NULL;
+}
+
+void rollsum_init(Rollsum *r) {
+    r->s1 = BUP_WINDOWSIZE * BUP_ROLL_BASE;
+    r->s2 = BUP_WINDOWSIZE * (BUP_WINDOWSIZE - 1) * BUP_ROLL_BASE;
+    r->wofs = 0;
+    memset(r->window, 0, BUP_WINDOWSIZE);
+}
+
+void rollsum_roll(Rollsum *r, uint8_t c) {
+    uint8_t drop = r->window[r->wofs];
+    r->s1 += c - drop;
+    r->s2 += r->s1 - (BUP_WINDOWSIZE * (drop + BUP_ROLL_BASE));
+    r->window[r->wofs] = c;
+    r->wofs = (r->wofs + 1) % BUP_WINDOWSIZE;
+}
+
+uint32_t rollsum_digest(const Rollsum *r) {
+    return (r->s1 << BUP_ROLL_SHIFT) | (r->s2 & BUP_ROLL_MASK);
+}
+
+static bup_chunk *chunk_create(git_odb *odb, const void *data, size_t len) {
+    git_oid oid;
+    if (git_odb_write(&oid, odb, data, len, GIT_OBJECT_BLOB) < 0)
+        return NULL;
+
+    bup_chunk *c = malloc(sizeof(*c));
+    if (!c)
+        return NULL;
+
+    git_oid_cpy(&c->oid, &oid);
+    c->len = len;
+    c->next = NULL;
+    chunk_total_size += len;
+    chunk_count++;
+    return c;
+}
+
+bup_chunk *chunk_get_or_create(git_odb *odb, bup_chunk **pool,
+                               const void *data, size_t len) {
+    git_oid oid;
+    if (git_odb_hash(&oid, data, len, GIT_OBJECT_BLOB) < 0)
+        return NULL;
+    bup_chunk *c = find_chunk(*pool, &oid);
+    if (c)
+        return c;
+
+    c = chunk_create(odb, data, len);
+    if (!c)
+        return NULL;
+    c->next = *pool;
+    *pool = c;
+    return c;
+}
+
+void chunk_pool_free(bup_chunk **pool) {
+    bup_chunk *c = *pool;
+    while (c) {
+        bup_chunk *next = c->next;
+        chunk_total_size -= c->len;
+        chunk_count--;
+        free(c);
+        c = next;
+    }
+    *pool = NULL;
+}
+


### PR DESCRIPTION
## Summary
- drop custom bup_object and bup_obj_chunk structures
- parse chunk lists directly with helper function
- simplify chunk pool implementation
- rely on libgit2 data models for storing chunks

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_684f3541e86c8324ad6f06a4da0d50e9