### PR TITLE
Refactor backend chunk handling

### DIFF
--- a/include/bup_odb.h
+++ b/include/bup_odb.h
@@ -2,10 +2,19 @@
 #define BUP_ODB_H
 
 #include <git2.h>
+#include <git2/sys/odb_backend.h>
+#include "chunk_utils.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+typedef struct bup_odb_backend {
+    git_odb_backend parent;
+    char *path;
+    git_odb *odb;
+    bup_chunk *chunk_pool;
+} bup_odb_backend;
 
 int bup_odb_backend_new(git_odb_backend **out, const char *path);
 
@@ -15,8 +24,10 @@ int bup_backend_write_calls(void);
 int bup_backend_free_calls(void);
 int bup_backend_chunk_count(void);
 size_t bup_backend_total_size(void);
-size_t bup_backend_object_chunks(git_odb_backend *backend, const git_oid *oid,
-                                 git_oid **chunk_oids, size_t **lengths);
+size_t bup_backend_object_chunk_count(git_odb_backend *backend,
+                                      const git_oid *oid,
+                                      git_oid **chunk_oids,
+                                      size_t **lengths);
 
 #ifdef __cplusplus
 }

--- a/include/chunk_utils.h
+++ b/include/chunk_utils.h
@@ -37,5 +37,7 @@ bup_chunk *chunk_get_or_create(git_odb *odb, bup_chunk **pool,
 void chunk_pool_free(bup_chunk **pool);
 int chunk_pool_count(void);
 size_t chunk_pool_total_size(void);
+int parse_chunk_list(const char *data, size_t size, git_oid **oids,
+                     size_t **lengths, size_t *count);
 
 #endif /* CHUNK_UTILS_H */

--- a/tests/test_chunk_reuse.c
+++ b/tests/test_chunk_reuse.c
@@ -26,7 +26,7 @@ static size_t store_blob_and_get_chunks(git_odb_backend *backend,
                                         size_t **lens)
 {
     assert(backend->write(backend, oid, data, size, GIT_OBJECT_BLOB) == 0);
-    return bup_backend_object_chunks(backend, oid, chunks, lens);
+    return bup_backend_object_chunk_count(backend, oid, chunks, lens);
 }
 
 static int chunk_reused(const git_oid *chunk, const git_oid *old_chunks,

--- a/tests/test_cli.c
+++ b/tests/test_cli.c
@@ -33,7 +33,7 @@ static size_t store_blob_get_chunks(git_odb_backend *backend, const void *data,
                                     git_oid **chunks, size_t **lens)
 {
     assert(backend->write(backend, oid, data, len, GIT_OBJECT_BLOB) == 0);
-    return bup_backend_object_chunks(backend, oid, chunks, lens);
+    return bup_backend_object_chunk_count(backend, oid, chunks, lens);
 }
 
 static int chunk_reused(const git_oid *chunk, const git_oid *old_chunks,

--- a/tests/test_many_commits.c
+++ b/tests/test_many_commits.c
@@ -32,7 +32,7 @@ static size_t store_blob_get_chunks(git_odb_backend *backend, const void *data,
                                     size_t **lens)
 {
     assert(backend->write(backend, oid, data, len, GIT_OBJECT_BLOB) == 0);
-    return bup_backend_object_chunks(backend, oid, chunks, lens);
+    return bup_backend_object_chunk_count(backend, oid, chunks, lens);
 }
 
 static size_t count_reused(const git_oid *new_chunks, size_t new_count,


### PR DESCRIPTION
## Summary
- expose `bup_odb_backend` structure in the public header
- move `parse_chunk_list` and chunk counting into `chunk_utils.c`
- rename `bup_backend_object_chunks` to `bup_backend_object_chunk_count`
- deduplicate code in `bup_backend_write`

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_684f9a4800c48324a849781a1eb8de50