### PR TITLE
Fix loose object count test

### DIFF
--- a/tests/test_repack_fsck.c
+++ b/tests/test_repack_fsck.c
@@ -127,6 +127,8 @@ static size_t count_loose_objects(const char *repo)
     size_t count = 0;
     struct dirent *ent;
     while ((ent = readdir(d))) {
+        if (!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, ".."))
+            continue;
         if (strlen(ent->d_name) != 2)
             continue;
         char subdir[512];


### PR DESCRIPTION
## Summary
- fix counting logic in `test_repack_fsck`

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure --verbose`

------
https://chatgpt.com/codex/tasks/task_e_685068e82d108324949ac33ecbf59c74